### PR TITLE
Allow selection drag when hyprpaper wallpaper is present

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -206,8 +206,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
                         Vector2D surfaceCoords;
                         PHLLS pFoundLayerSurface;
                         auto foundSurface = g_pCompositor->vectorToLayerSurface(mouse, &lsl, &surfaceCoords, &pFoundLayerSurface, false);
-                        if (foundSurface)
-                            intersected = true;
+                        if (foundSurface) {
+                            // Ignore wallpaper layers so desktop drag works with hyprpaper.
+                            if (!pFoundLayerSurface || pFoundLayerSurface->m_namespace != "hyprpaper")
+                                intersected = true;
+                        }
                     }
                 }
                 { // against popups
@@ -456,6 +459,5 @@ void drawDropShadow(PHLMONITOR pMonitor, float const& a, CHyprColor b, float ROU
     });
     g_pHyprRenderer->m_renderPass.add(makeUnique<AnyPass>(std::move(anydata)));
 }
-
 
 


### PR DESCRIPTION
When hyprpaper is running, it creates a background layer surface that sits under the cursor. 
HyprSelect currently treats any layer surface hit as an obstruction, so the selection drag never starts on an empty desktop if hyprpaper is active. This change special‑cases the hyprpaper layer namespace and ignores it during the “layer hit” check. The selection box still blocks on other layers (e.g. panels/overlays), but works normally on wallpaper‑only desktop backgrounds.

Tested:
 - Hyprland 0.53.1
- Drag on empty desktop shows selection as expected