### PR TITLE
add hash check before loading

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -130,6 +130,14 @@ void drawSelectionBox(CBox selectionBox, float alpha) {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
+    // check that header version aligns with running version
+    const std::string COMPOSITOR_HASH = __hyprland_api_get_hash();
+    const std::string CLIENT_HASH     = __hyprland_api_get_client_hash();
+    if (COMPOSITOR_HASH != CLIENT_HASH) {
+        HyprlandAPI::addNotification(PHANDLE, "[hyprselect] failed to load, version mismatch!", CHyprColor{1.0, 0.2, 0.2, 1.0}, 10000);
+        throw std::runtime_error(std::format("version mismatch, built against: {}, running compositor: {}", CLIENT_HASH, COMPOSITOR_HASH));
+    }
+
     using namespace Config::Values;
 
     g_pShouldRound   = makeShared<CBoolValue>("plugin:hyprselect:should_round", "Whether the selection box has rounded corners", (Config::BOOL) false);


### PR DESCRIPTION
Adds a hash check which compares the hyprland version the plugin was compiled against with the actual running hyprland version, as recommended in the [wiki here](https://wiki.hypr.land/Plugins/Development/Getting-Started/#the-basic-parts-of-the-plugin). This will prevent people from loading the plugin if not explicitly built against the current hyprland version.

This is especially important for people which daily drive -git so subtle changes come often and forgetting to rebuild the plugin, or loading an old version because the rebuild failed, can cause all sorts of crashes.

Anyways, thanks for this important plugin, I didn't know what I was missing out on.